### PR TITLE
Support _FILE suffix

### DIFF
--- a/envee/__init__.py
+++ b/envee/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "0.2.0dev"
 
-from envee.envee import environment, field, read, NamingStrategy
+from envee.envee import NamingStrategy, environment, field, read
 
 __all__ = ["read", "environment", "field", "NamingStrategy"]

--- a/envee/envee.py
+++ b/envee/envee.py
@@ -35,12 +35,38 @@ class NamingStrategy(ABC):
     @staticmethod
     @abstractmethod
     def get_env_variable_name(field_name: str) -> str:
+        """Derive environment variable name from field name
+        Parameters
+        ----------
+        field_name : str
+            The name of the field
+
+        Returns
+        -------
+        str
+            The name of the corresponding environment variable
+        """
         ...  # pytype: disable=bad-return-type
 
     @staticmethod
     @abstractmethod
     def get_file_name(field_name: str) -> str:
+        """Derive file name from field name
+        Parameters
+        ----------
+        field_name : str
+            The name of the field
+
+        Returns
+        -------
+        str
+            The name of the corresponding file
+        """
         ...  # pytype: disable=bad-return-type
+
+    @staticmethod
+    def get_file_suffix() -> str:
+        return "_FILE"
 
 
 class DefaultNamingStrategy(NamingStrategy):
@@ -258,8 +284,15 @@ def read(
         value = None
         # Read from file
         if read_file:
+
+            env_variable_with_file_suffix = (
+                naming_strategy.get_env_variable_name(field_name)
+                + naming_strategy.get_file_suffix()
+            )
             if field_metadata.file_path:
                 file_path = field_metadata.file_path
+            elif env_variable_with_file_suffix in os.environ:
+                file_path = os.environ[env_variable_with_file_suffix]
             else:
                 if field_metadata.file_location:
                     location = field_metadata.file_location

--- a/tests/test_envee.py
+++ b/tests/test_envee.py
@@ -299,5 +299,22 @@ def test_naming_strategy(monkeypatch, tmpdir):
     env = envee.read(
         Environment,
         default_files_location=p_dir.realpath(),
-        naming_strategy=CustomNamingStrategy
+        naming_strategy=CustomNamingStrategy,
     )
+
+
+def test_file_suffix(monkeypatch, tmpdir):
+
+    p_dir = tmpdir.mkdir("secrets")
+    p = p_dir.join("one")
+    p.write("1")
+
+    monkeypatch.setenv("ONE_FILE", str(p.realpath()))
+
+    @envee.environment
+    class Environment:
+        ONE: str
+
+    env = envee.read(Environment)
+
+    assert env.ONE == "1"


### PR DESCRIPTION
Support <variable name>_FILE syntax, that is used e.g. by the postgres docker image: https://hub.docker.com/_/postgres

E.g. for the following example
```
    @envee.environment
    class Environment:
        POSTGRES_PASSWORD: str
```

If there is a POSTGRES_PASSWORD_FILE environment variable containing an existing path to a file, e.g. `/run/secrets/postgres-passwd`,  POSTGRES_PASSWORD will be read from /run/secrets/postgres-passwd.